### PR TITLE
Support having private fields

### DIFF
--- a/lib/utils/js-parser.js
+++ b/lib/utils/js-parser.js
@@ -24,6 +24,8 @@ const options = {
     'nullishCoalescingOperator',
     'optionalChaining',
     'decorators-legacy',
+    'classPrivateProperties',
+    'classPrivateMethods'
   ],
 };
 

--- a/lib/utils/js-parser.js
+++ b/lib/utils/js-parser.js
@@ -24,6 +24,8 @@ const options = {
     'nullishCoalescingOperator',
     'optionalChaining',
     'decorators-legacy',
+    'classPrivateProperties',
+    'classPrivateMethods',
   ],
 };
 


### PR DESCRIPTION
I recently ran to the following error

```
SyntaxError: This experimental syntax requires enabling one of the following parser plugin(s): 
```

The reason is *.js files contains private variable

```
export default class Module extends Component {
  ...
  #foo = ..
 ...
}
```
This RB adding support for it.

Run locally with this change, codemod runs successfully.