### PR TITLE
Use correct babel configuration for typescript

### DIFF
--- a/lib/utils/js-parser.js
+++ b/lib/utils/js-parser.js
@@ -24,6 +24,7 @@ const options = {
     'nullishCoalescingOperator',
     'optionalChaining',
     'decorators-legacy',
+    'typescript',
   ],
 };
 

--- a/test/fixtures/app/example-ts/classic-to-flat.js
+++ b/test/fixtures/app/example-ts/classic-to-flat.js
@@ -37,6 +37,7 @@ module.exports = {
       'layout-name': {
         'has-layout-name.ts': [
           '// top-level-component.ts',
+          'interface IArgs {key: string}',
           'Component.extend({ layoutName: "components/layout-name/layout-name-template" });',
         ].join('\n'),
       },

--- a/test/fixtures/app/example-ts/classic-to-nested.js
+++ b/test/fixtures/app/example-ts/classic-to-nested.js
@@ -46,6 +46,7 @@ module.exports = {
       'layout-name': {
         'has-layout-name.ts': [
           '// top-level-component.ts',
+          'interface IArgs {key: string}',
           'Component.extend({ layoutName: "components/layout-name/layout-name-template" });',
         ].join('\n'),
       },

--- a/test/fixtures/app/example-ts/input.js
+++ b/test/fixtures/app/example-ts/input.js
@@ -22,11 +22,11 @@ module.exports = {
           'super-nested-component.ts': '// nested1/nested2/super-nested-component.ts',
         },
       },
-
       // A component with layoutName
       'layout-name': {
         'has-layout-name.ts': [
           '// top-level-component.ts',
+          'interface IArgs {key: string}',
           'Component.extend({ layoutName: "components/layout-name/layout-name-template" });',
         ].join('\n'),
       },


### PR DESCRIPTION
Fixes #21

I know this has been floating around for a while, but just starting the process of migrating a large non-pods typescript codebase. 

Happy to add more explicit tests if you want, but it was kind of difficult to reason about how to make all the fixtures align correctly.

see: https://babeljs.io/docs/en/babel-parser#options
